### PR TITLE
Added Mark as Done button to Doctor Appointments

### DIFF
--- a/swasthyalink-frontend/src/pages/DoctorAppointments.js
+++ b/swasthyalink-frontend/src/pages/DoctorAppointments.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import './Dashboard.css'; // reuse existing styling
 import { db } from '../firebase';
-import { collection, query, where, getDocs } from 'firebase/firestore';
+import { collection, query, where, getDocs, updateDoc, doc } from 'firebase/firestore';
 import { useAuth } from '../context/AuthContext';
 
 export default function DoctorAppointments() {
@@ -36,6 +36,21 @@ export default function DoctorAppointments() {
     fetchAppointments();
   }, [user]);
 
+  const markAsDone = async (appointmentId) => {
+    try {
+      const docRef = doc(db, 'appointments', appointmentId);
+      await updateDoc(docRef, { status: 'done' });
+      setAppointments(prev =>
+        prev.map(app =>
+          app.id === appointmentId ? { ...app, status: 'done' } : app
+        )
+      );
+    } catch (error) {
+      console.error('Error updating appointment:', error);
+      alert('Failed to mark as done.');
+    }
+  };
+
   return (
     <div className="dashboard-container">
       <h2 className="dashboard-title">📅 My Appointments</h2>
@@ -50,6 +65,12 @@ export default function DoctorAppointments() {
               <h3>{app.date} at {app.time}</h3>
               <p><strong>Patient:</strong> {app.patientEmail}</p>
               <p><strong>Reason:</strong> {app.reason || 'N/A'}</p>
+              <p><strong>Status:</strong> {app.status || 'pending'}</p>
+              {app.status !== 'done' && (
+                <button onClick={() => markAsDone(app.id)}>
+                  ✅ Mark as Done
+                </button>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
- Added a "Mark as Done" button to each appointment card in the Doctor Appointments view.
- Displayed the status field (pending/done) for clarity.
- When the button is clicked, the appointment document is updated in Firestore to set status: 'done'.
- The UI updates immediately after marking an appointment as done.